### PR TITLE
vk_backend: optimize subpasses using local read extension

### DIFF
--- a/intern/ghost/intern/GHOST_ContextVK.cc
+++ b/intern/ghost/intern/GHOST_ContextVK.cc
@@ -2,6 +2,11 @@
  *
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
+/* ​​Changes from Qualcomm Innovation Center, Inc.are provided under the following license :
+   Copyright(c) 2024 Qualcomm Innovation Center, Inc.All rights reserved.
+   SPDX - License - Identifier : BSD - 3 - Clause - Clear
+*/
+
 /** \file
  * \ingroup GHOST
  */
@@ -268,6 +273,16 @@ class GHOST_DeviceVK {
     if (has_extensions({VK_EXT_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_EXTENSION_NAME})) {
       dynamic_rendering_unused_attachments.pNext = device_create_info_p_next;
       device_create_info_p_next = &dynamic_rendering_unused_attachments;
+    }
+
+    VkPhysicalDeviceDynamicRenderingLocalReadFeaturesKHR
+      dynamic_rendering_local_read = {};
+    dynamic_rendering_local_read.sType =
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_LOCAL_READ_FEATURES_KHR;
+    dynamic_rendering_local_read.dynamicRenderingLocalRead = VK_TRUE;
+    if (has_extensions({ VK_KHR_DYNAMIC_RENDERING_LOCAL_READ_EXTENSION_NAME })) {
+      dynamic_rendering_local_read.pNext = device_create_info_p_next;
+      device_create_info_p_next = &dynamic_rendering_local_read;
     }
 
     /* Query for Mainenance4 (core in Vulkan 1.3). */
@@ -980,6 +995,11 @@ GHOST_TSuccess GHOST_ContextVK::initializeDrawingContext()
     required_device_extensions.push_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
   }
   required_device_extensions.push_back(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+
+  required_device_extensions.push_back(VK_KHR_DYNAMIC_RENDERING_LOCAL_READ_EXTENSION_NAME);
+
+  required_device_extensions.push_back(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
+
   /* NOTE: marking this as an optional extension, but is actually required. Renderdoc doesn't
    * create a device with this extension, but seems to work when not requesting the extension.
    */

--- a/source/blender/gpu/intern/gpu_shader_create_info.cc
+++ b/source/blender/gpu/intern/gpu_shader_create_info.cc
@@ -2,6 +2,11 @@
  *
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
+ /* ​​Changes from Qualcomm Innovation Center, Inc.are provided under the following license :
+    Copyright(c) 2024 Qualcomm Innovation Center, Inc.All rights reserved.
+    SPDX - License - Identifier : BSD - 3 - Clause - Clear
+ */
+
 /** \file
  * \ingroup gpu
  *
@@ -221,6 +226,8 @@ void ShaderCreateInfo::finalize()
         case Resource::BindType::IMAGE:
           res.slot = images++;
           break;
+        case Resource::BindType::INPUT_ATTACHMENT:
+          break;
       }
     };
 
@@ -337,6 +344,8 @@ void ShaderCreateInfo::validate_merge(const ShaderCreateInfo &other_info)
           return ubos.add(res.slot);
         case Resource::BindType::IMAGE:
           return ssbos.add(res.slot);
+        case Resource::BindType::INPUT_ATTACHMENT:
+          return true;
         default:
           return false;
       }
@@ -356,6 +365,8 @@ void ShaderCreateInfo::validate_merge(const ShaderCreateInfo &other_info)
             break;
           case Resource::BindType::IMAGE:
             std::cout << "Image " << res.image.name;
+            break;
+          case Resource::BindType::INPUT_ATTACHMENT:
             break;
           default:
             std::cout << "Unknown Type";

--- a/source/blender/gpu/intern/gpu_shader_create_info.hh
+++ b/source/blender/gpu/intern/gpu_shader_create_info.hh
@@ -2,6 +2,11 @@
  *
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
+ /* ​​Changes from Qualcomm Innovation Center, Inc.are provided under the following license :
+    Copyright(c) 2024 Qualcomm Innovation Center, Inc.All rights reserved.
+    SPDX - License - Identifier : BSD - 3 - Clause - Clear
+ */
+
 /** \file
  * \ingroup gpu
  *
@@ -507,6 +512,7 @@ struct ShaderCreateInfo {
       STORAGE_BUFFER,
       SAMPLER,
       IMAGE,
+      INPUT_ATTACHMENT,
     };
 
     BindType bind_type;
@@ -544,6 +550,8 @@ struct ShaderCreateInfo {
           TEST_EQUAL(*this, b, image.type);
           TEST_EQUAL(*this, b, image.qualifiers);
           TEST_EQUAL(*this, b, image.name);
+          break;
+        case INPUT_ATTACHMENT:
           break;
       }
       return true;
@@ -1104,6 +1112,9 @@ struct ShaderCreateInfo {
           break;
         case Resource::BindType::IMAGE:
           stream << "IMAGE(" << res.slot << ", " << res.image.name << ")" << std::endl;
+          break;
+        case Resource::BindType::INPUT_ATTACHMENT:
+          stream << "INPUT_ATTACHMENT(" << res.slot << ", " << res.image.name << ")" << std::endl;
           break;
       }
     };

--- a/source/blender/gpu/intern/gpu_shader_interface.hh
+++ b/source/blender/gpu/intern/gpu_shader_interface.hh
@@ -11,6 +11,11 @@
  * A shader interface can be shared between two similar shaders.
  */
 
+ /* ​​Changes from Qualcomm Innovation Center, Inc.are provided under the following license :
+    Copyright(c) 2024 Qualcomm Innovation Center, Inc.All rights reserved.
+    SPDX - License - Identifier : BSD - 3 - Clause - Clear
+ */
+
 #pragma once
 
 #include <cstring> /* required for STREQ later on. */
@@ -107,6 +112,11 @@ class ShaderInterface {
   }
 
   inline const ShaderInput *texture_get(const int binding) const
+  {
+    return input_lookup(inputs_ + attr_len_ + ubo_len_, uniform_len_, binding);
+  }
+
+  inline const ShaderInput* input_attachment_get(const int binding) const
   {
     return input_lookup(inputs_ + attr_len_ + ubo_len_, uniform_len_, binding);
   }

--- a/source/blender/gpu/vulkan/render_graph/vk_command_builder.hh
+++ b/source/blender/gpu/vulkan/render_graph/vk_command_builder.hh
@@ -2,6 +2,11 @@
  *
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
+ /* ​​Changes from Qualcomm Innovation Center, Inc.are provided under the following license :
+    Copyright(c) 2024 Qualcomm Innovation Center, Inc.All rights reserved.
+    SPDX - License - Identifier : BSD - 3 - Clause - Clear
+ */
+
 /** \file
  * \ingroup gpu
  */
@@ -122,9 +127,11 @@ class VKCommandBuilder {
   void build_pipeline_barriers(VKRenderGraph &render_graph,
                                VKCommandBufferInterface &command_buffer,
                                NodeHandle node_handle,
-                               VkPipelineStageFlags pipeline_stage);
+                               VkPipelineStageFlags pipeline_stage,
+                               bool within_rendering = false);
   void reset_barriers();
-  void send_pipeline_barriers(VKCommandBufferInterface &command_buffer);
+  void send_pipeline_barriers(VKCommandBufferInterface &command_buffer,
+                              bool within_rendering);
 
   void add_buffer_barriers(VKRenderGraph &render_graph,
                            NodeHandle node_handle,
@@ -141,7 +148,8 @@ class VKCommandBuilder {
 
   void add_image_barriers(VKRenderGraph &render_graph,
                           NodeHandle node_handle,
-                          VkPipelineStageFlags node_stages);
+                          VkPipelineStageFlags node_stages,
+                          bool within_rendering);
   void add_image_barrier(VkImage vk_image,
                          VkAccessFlags src_access_mask,
                          VkAccessFlags dst_access_mask,
@@ -152,10 +160,12 @@ class VKCommandBuilder {
                          uint32_t layer_count = VK_REMAINING_ARRAY_LAYERS);
   void add_image_read_barriers(VKRenderGraph &render_graph,
                                NodeHandle node_handle,
-                               VkPipelineStageFlags node_stages);
+                               VkPipelineStageFlags node_stages,
+                               bool within_rendering);
   void add_image_write_barriers(VKRenderGraph &render_graph,
                                 NodeHandle node_handle,
-                                VkPipelineStageFlags node_stages);
+                                VkPipelineStageFlags node_stages,
+                                bool within_rendering);
 
   /**
    * Ensure that the debug group associated with the given node_handle is activated.
@@ -201,6 +211,8 @@ class VKCommandBuilder {
    * textures to be kept for when the rendering is resumed.
    */
   void layer_tracking_end(VKCommandBufferInterface &command_buffer, bool suspend);
+
+  bool node_has_input_attachments(const VKRenderGraph& render_graph, NodeHandle node);
 };
 
 }  // namespace blender::gpu::render_graph

--- a/source/blender/gpu/vulkan/render_graph/vk_resource_access_info.cc
+++ b/source/blender/gpu/vulkan/render_graph/vk_resource_access_info.cc
@@ -2,6 +2,11 @@
  *
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
+ /* ​​Changes from Qualcomm Innovation Center, Inc.are provided under the following license :
+    Copyright(c) 2024 Qualcomm Innovation Center, Inc.All rights reserved.
+    SPDX - License - Identifier : BSD - 3 - Clause - Clear
+ */
+
 /** \file
  * \ingroup gpu
  */
@@ -20,9 +25,9 @@ VkImageLayout VKImageAccess::to_vk_image_layout() const
   }
 
   if (vk_access_flags &
-      (VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT))
+    (VK_ACCESS_INPUT_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT))
   {
-    return VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    return VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ_KHR;
   }
 
   // TODO: Add ATTACHMENT_READ_ONLY_OPTIMAL

--- a/source/blender/gpu/vulkan/vk_backend.cc
+++ b/source/blender/gpu/vulkan/vk_backend.cc
@@ -2,6 +2,11 @@
  *
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
+ /* ​​Changes from Qualcomm Innovation Center, Inc.are provided under the following license :
+    Copyright(c) 2024 Qualcomm Innovation Center, Inc.All rights reserved.
+    SPDX - License - Identifier : BSD - 3 - Clause - Clear
+ */
+
 /** \file
  * \ingroup gpu
  */
@@ -51,8 +56,11 @@ static Vector<StringRefNull> missing_capabilities_get(VkPhysicalDevice vk_physic
       dynamic_rendering_unused_attachments = {};
   dynamic_rendering_unused_attachments.sType =
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_FEATURES_EXT;
+  VkPhysicalDeviceDynamicRenderingLocalReadFeaturesKHR dynamic_rendering_local_read = {};
+  dynamic_rendering_local_read.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_LOCAL_READ_FEATURES_KHR;
   features.pNext = &dynamic_rendering;
   dynamic_rendering.pNext = &dynamic_rendering_unused_attachments;
+  dynamic_rendering_unused_attachments.pNext = &dynamic_rendering_local_read;
 
   vkGetPhysicalDeviceFeatures2(vk_physical_device, &features);
 #ifndef __APPLE__
@@ -87,6 +95,9 @@ static Vector<StringRefNull> missing_capabilities_get(VkPhysicalDevice vk_physic
   if (dynamic_rendering.dynamicRendering == VK_FALSE) {
     missing_capabilities.append("dynamic rendering");
   }
+  if (dynamic_rendering_local_read.dynamicRenderingLocalRead == VK_FALSE) {
+    missing_capabilities.append("dynamic rendering local read");
+  }
 
   /* Check device extensions. */
   uint32_t vk_extension_count;
@@ -105,6 +116,12 @@ static Vector<StringRefNull> missing_capabilities_get(VkPhysicalDevice vk_physic
   }
   if (!extensions.contains(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME)) {
     missing_capabilities.append(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+  }
+  if (!extensions.contains(VK_KHR_DYNAMIC_RENDERING_LOCAL_READ_EXTENSION_NAME)) {
+    missing_capabilities.append(VK_KHR_DYNAMIC_RENDERING_LOCAL_READ_EXTENSION_NAME);
+  }
+  if (!extensions.contains(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME)) {
+    missing_capabilities.append(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
   }
 
   return missing_capabilities;

--- a/source/blender/gpu/vulkan/vk_common.cc
+++ b/source/blender/gpu/vulkan/vk_common.cc
@@ -2,6 +2,11 @@
  *
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
+ /* ​​Changes from Qualcomm Innovation Center, Inc.are provided under the following license :
+    Copyright(c) 2024 Qualcomm Innovation Center, Inc.All rights reserved.
+    SPDX - License - Identifier : BSD - 3 - Clause - Clear
+ */
+
 /** \file
  * \ingroup gpu
  */
@@ -1017,6 +1022,8 @@ VkDescriptorType to_vk_descriptor_type(const shader::ShaderCreateInfo::Resource 
       return VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
     case shader::ShaderCreateInfo::Resource::BindType::UNIFORM_BUFFER:
       return VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    case shader::ShaderCreateInfo::Resource::BindType::INPUT_ATTACHMENT:
+      return VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT;
   }
   BLI_assert_unreachable();
   return VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;

--- a/source/blender/gpu/vulkan/vk_descriptor_set.hh
+++ b/source/blender/gpu/vulkan/vk_descriptor_set.hh
@@ -2,6 +2,11 @@
  *
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
+ /* ​​Changes from Qualcomm Innovation Center, Inc.are provided under the following license :
+    Copyright(c) 2024 Qualcomm Innovation Center, Inc.All rights reserved.
+    SPDX - License - Identifier : BSD - 3 - Clause - Clear
+ */
+
 /** \file
  * \ingroup gpu
  */
@@ -109,6 +114,9 @@ class VKDescriptorSetTracker {
   void bind_image_resource(const VKStateManager &state_manager,
                            const VKResourceBinding &resource_binding,
                            render_graph::VKResourceAccessInfo &access_info);
+  void bind_input_attachment_resource(const VKStateManager& state_manager,
+                                      const VKResourceBinding& resource_binding,
+                                      render_graph::VKResourceAccessInfo& access_info);
   void bind_texture_resource(const VKDevice &device,
                              const VKStateManager &state_manager,
                              const VKResourceBinding &resource_binding,

--- a/source/blender/gpu/vulkan/vk_framebuffer.cc
+++ b/source/blender/gpu/vulkan/vk_framebuffer.cc
@@ -2,6 +2,11 @@
  *
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
+ /* ​​Changes from Qualcomm Innovation Center, Inc.are provided under the following license :
+    Copyright(c) 2024 Qualcomm Innovation Center, Inc.All rights reserved.
+    SPDX - License - Identifier : BSD - 3 - Clause - Clear
+ */
+
 /** \file
  * \ingroup gpu
  */
@@ -282,33 +287,17 @@ static void set_load_store(VkRenderingAttachmentInfo &r_rendering_attachment,
 /** \name Sub-pass transition
  * \{ */
 
-void VKFrameBuffer::subpass_transition_impl(const GPUAttachmentState depth_attachment_state,
+void VKFrameBuffer::subpass_transition_impl(const GPUAttachmentState,
                                             Span<GPUAttachmentState> color_attachment_states)
 {
-  /* TODO: this is a fallback implementation. We should also provide support for
-   * `VK_EXT_dynamic_rendering_local_read`. This extension is only supported on Windows
-   * platforms (2024Q2), but would reduce the rendering synchronization overhead. */
-  VKContext &context = *VKContext::get();
-  if (is_rendering_) {
-    rendering_end(context);
+  VKContext& context = *VKContext::get();
 
-    /* TODO: this might need a better implementation:
-     * READ -> DONTCARE
-     * WRITE -> LOAD, STORE based on previous value.
-     * IGNORE -> DONTCARE -> IGNORE */
-    load_stores.fill(default_load_store());
-  }
-
-  attachment_states_[GPU_FB_DEPTH_ATTACHMENT] = depth_attachment_state;
-  attachment_states_.as_mutable_span()
-      .slice(GPU_FB_COLOR_ATTACHMENT0, color_attachment_states.size())
-      .copy_from(color_attachment_states);
   for (int index : IndexRange(color_attachment_states.size())) {
     if (color_attachment_states[index] == GPU_ATTACHMENT_READ) {
-      VKTexture *texture = unwrap(unwrap(color_tex(index)));
+      VKTexture* texture = unwrap(unwrap(color_tex(index)));
       if (texture) {
-        context.state_manager_get().texture_bind(
-            texture, GPUSamplerState::default_sampler(), index);
+        context.state_manager_get().image_bind(
+          texture, index);
       }
     }
   }
@@ -576,7 +565,7 @@ void VKFrameBuffer::rendering_ensure(VKContext &context)
       vk_image_view = color_texture.image_view_get(image_view_info).vk_handle();
     }
     attachment_info.imageView = vk_image_view;
-    attachment_info.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    attachment_info.imageLayout = VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ_KHR;
     set_load_store(attachment_info, load_stores[color_attachment_index]);
 
     access_info.images.append(

--- a/source/blender/gpu/vulkan/vk_framebuffer.hh
+++ b/source/blender/gpu/vulkan/vk_framebuffer.hh
@@ -2,6 +2,11 @@
  *
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
+ /* ​​Changes from Qualcomm Innovation Center, Inc.are provided under the following license :
+    Copyright(c) 2024 Qualcomm Innovation Center, Inc.All rights reserved.
+    SPDX - License - Identifier : BSD - 3 - Clause - Clear
+ */
+
 /** \file
  * \ingroup gpu
  */

--- a/source/blender/gpu/vulkan/vk_shader.cc
+++ b/source/blender/gpu/vulkan/vk_shader.cc
@@ -2,6 +2,11 @@
  *
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
+ /* ​​Changes from Qualcomm Innovation Center, Inc.are provided under the following license :
+    Copyright(c) 2024 Qualcomm Innovation Center, Inc.All rights reserved.
+    SPDX - License - Identifier : BSD - 3 - Clause - Clear
+ */
+
 /** \file
  * \ingroup gpu
  */
@@ -376,6 +381,10 @@ static void print_resource(std::ostream &os,
       print_qualifier(os, res.image.qualifiers);
       print_image_type(os, res.image.type, res.bind_type);
       os << res.image.name << ";\n";
+      break;
+    case ShaderCreateInfo::Resource::BindType::INPUT_ATTACHMENT:
+      os << "input_attachment ";
+      // TODO
       break;
     case ShaderCreateInfo::Resource::BindType::UNIFORM_BUFFER:
       array_offset = res.uniformbuf.name.find_first_of("[");
@@ -945,52 +954,30 @@ std::string VKShader::fragment_interface_declare(const shader::ShaderCreateInfo 
   ss << "layout(" << to_string(info.depth_write_) << ") out float gl_FragDepth;\n";
 
   ss << "\n/* Sub-pass Inputs. */\n";
+  uint32_t subpass_input_binding_index = 0;
   for (const ShaderCreateInfo::SubpassIn &input : info.subpass_inputs_) {
-    std::string image_name = "gpu_subpass_img_";
-    image_name += std::to_string(input.index);
+    std::string input_attachment_name = "gpu_input_attachment_";
+    input_attachment_name += std::to_string(input.index);
 
     /* Declare global for input. */
     ss << to_string(input.type) << " " << input.name << ";\n";
 
-    /* IMPORTANT: We assume that the frame-buffer will be layered or not based on the layer
-     * built-in flag. */
-    bool is_layered_fb = bool(info.builtins_ & BuiltinBits::LAYER);
-
-    /* Start with invalid value to detect failure cases. */
-    ImageType image_type = ImageType::FLOAT_BUFFER;
-    switch (to_component_type(input.type)) {
-      case Type::FLOAT:
-        image_type = is_layered_fb ? ImageType::FLOAT_2D_ARRAY : ImageType::FLOAT_2D;
-        break;
-      case Type::INT:
-        image_type = is_layered_fb ? ImageType::INT_2D_ARRAY : ImageType::INT_2D;
-        break;
-      case Type::UINT:
-        image_type = is_layered_fb ? ImageType::UINT_2D_ARRAY : ImageType::UINT_2D;
-        break;
-      default:
-        break;
+    Type component_type = to_component_type(input.type);
+    char typePrefix;
+    switch (component_type)
+    {
+    case Type::INT: typePrefix = 'i'; break;
+    case Type::UINT: typePrefix = 'u'; break;
+    default: typePrefix = ' '; break;
     }
-    /* Declare image. */
-    using Resource = ShaderCreateInfo::Resource;
-    /* NOTE(fclem): Using the attachment index as resource index might be problematic as it might
-     * collide with other resources. */
-    Resource res(Resource::BindType::SAMPLER, input.index);
-    res.sampler.type = image_type;
-    res.sampler.sampler = GPUSamplerState::default_sampler();
-    res.sampler.name = image_name;
-    print_resource(ss, interface_get(), res);
+    ss << "layout(input_attachment_index = " << (input.index) << ", binding = " << (subpass_input_binding_index++) << ") uniform "<< typePrefix << "subpassInput " << input_attachment_name << "; \n";
 
     char swizzle[] = "xyzw";
     swizzle[to_component_count(input.type)] = '\0';
 
-    std::string texel_co = (is_layered_fb) ? "ivec3(gl_FragCoord.xy, gpu_Layer)" :
-                                             "ivec2(gl_FragCoord.xy)";
-
     std::stringstream ss_pre;
-    /* Populate the global before main using imageLoad. */
-    ss_pre << "  " << input.name << " = texelFetch(" << image_name << ", " << texel_co << ", 0)."
-           << swizzle << ";\n";
+    /* Populate the global before main using subpassLoad. */
+    ss_pre << "  " << input.name << " = " << input.type << "( subpassLoad(" << input_attachment_name << ")." << swizzle << " ); \n";
 
     pre_main += ss_pre.str();
   }

--- a/source/blender/gpu/vulkan/vk_shader_compiler.cc
+++ b/source/blender/gpu/vulkan/vk_shader_compiler.cc
@@ -2,6 +2,11 @@
  *
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
+ /* ​​Changes from Qualcomm Innovation Center, Inc.are provided under the following license :
+    Copyright(c) 2024 Qualcomm Innovation Center, Inc.All rights reserved.
+    SPDX - License - Identifier : BSD - 3 - Clause - Clear
+ */
+
 /** \file
  * \ingroup gpu
  */
@@ -86,6 +91,10 @@ static bool compile_ex(shaderc::Compiler &compiler,
       shader_module.combined_sources, stage, full_name.c_str(), options);
   bool compilation_succeeded = shader_module.compilation_result.GetCompilationStatus() ==
                                shaderc_compilation_status_success;
+  if (!compilation_succeeded)
+  {
+    fprintf(stderr, "compile failed, error: %s", shader_module.compilation_result.GetErrorMessage().c_str());
+  }
   return compilation_succeeded;
 }
 

--- a/source/blender/gpu/vulkan/vk_texture.cc
+++ b/source/blender/gpu/vulkan/vk_texture.cc
@@ -2,6 +2,11 @@
  *
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
+ /* ​​Changes from Qualcomm Innovation Center, Inc.are provided under the following license :
+    Copyright(c) 2024 Qualcomm Innovation Center, Inc.All rights reserved.
+    SPDX - License - Identifier : BSD - 3 - Clause - Clear
+ */
+
 /** \file
  * \ingroup gpu
  */
@@ -406,6 +411,7 @@ static VkImageUsageFlags to_vk_image_usage(const eGPUTextureUsage usage,
       }
       else {
         result |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+        result |= VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
       }
     }
   }

--- a/source/blender/gpu/vulkan/vk_to_string.cc
+++ b/source/blender/gpu/vulkan/vk_to_string.cc
@@ -2,6 +2,11 @@
  *
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
+ /* ​​Changes from Qualcomm Innovation Center, Inc.are provided under the following license :
+    Copyright(c) 2024 Qualcomm Innovation Center, Inc.All rights reserved.
+    SPDX - License - Identifier : BSD - 3 - Clause - Clear
+ */
+
 /** \file
  * \ingroup gpu
  */
@@ -123,6 +128,9 @@ const char *to_string(const VkImageLayout vk_image_layout)
 
     case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
       return STRINGIFY(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+
+    case VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ_KHR:
+      return STRINGIFY(VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ_KHR);
 
     case VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL:
       return STRINGIFY(VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);


### PR DESCRIPTION
Optimize Vulkan backend using local read extension

There's some additional changes, in particular: cmake: update vulkan sdk version to 296, but I left that outside the PR....

tested with race_spaceship.blend using Viewport / vulkan renderer

![image](https://github.com/user-attachments/assets/8a51e632-ae88-41a9-ba1f-d1d8009afb9f)
